### PR TITLE
Use local instance for httpbin testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ jdk:
   - oraclejdk8
 before_install:
   - bash install_deps.sh
+  - sleep 1
+env:
+  - HTTPBIN_HOST="localhost:3000"
 notifications:
   slack: femoio:doI2URJh5J7kPNQBzg3V8AZO

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ before_install:
   - bash install_deps.sh
   - sleep 1
 env:
-  - HTTPBIN_HOST="localhost:3000"
+  - HTTPBIN_HOST="localhost:8000"
 notifications:
   slack: femoio:doI2URJh5J7kPNQBzg3V8AZO

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -6,4 +6,4 @@ mvn install -Dmaven.javadoc.skip=true -DskipTests=true -B -V
 cd ..
 
 pip install --user gunicorn httpbin
-gunicorn httpbin:app
+gunicorn httpbin:app > /dev/null &

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -4,3 +4,6 @@ git clone https://gitlab.com/xjs/dynamic.git dynamic
 cd dynamic
 mvn install -Dmaven.javadoc.skip=true -DskipTests=true -B -V
 cd ..
+
+pip install gunicorn httpbin
+gunicorn httpbin:app

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -5,5 +5,5 @@ cd dynamic
 mvn install -Dmaven.javadoc.skip=true -DskipTests=true -B -V
 cd ..
 
-pip install gunicorn httpbin
+pip install --user gunicorn httpbin
 gunicorn httpbin:app

--- a/src/test/java/io/femo/http/HttpsTest.java
+++ b/src/test/java/io/femo/http/HttpsTest.java
@@ -22,7 +22,7 @@ public class HttpsTest {
     private static JsonParser parser;
 
     @Rule
-    public TestRule timeout = new DisableOnDebug(new Timeout(20, TimeUnit.SECONDS));
+    public TestRule timeout = new DisableOnDebug(new Timeout(30, TimeUnit.SECONDS));
 
     @BeforeClass
     public static void setUp() throws Exception {


### PR DESCRIPTION
By using a local instance of httpbin on the CI server testing can be made faster and builds won't break anymore because of timeouts.
